### PR TITLE
CI determine the value for ds-ver

### DIFF
--- a/.github/workflows/ci-docs-test.yml
+++ b/.github/workflows/ci-docs-test.yml
@@ -26,7 +26,11 @@ jobs:
       id: get-version
       shell: bash
       run: |
-          VERSION=$(curl -s -L -H "Accept: application/vnd.github+json" https://api.github.com/repos/ONLYOFFICE/document-server-package/branches | jq -r '.[] | .name | select(.|test("hotfix/*") or test("release/*"))' | awk -F '/v' '{print $2}')
+          if curl -s -L -H "Accept: application/vnd.github+json" https://api.github.com/repos/ONLYOFFICE/document-server-package/branches | jq -r '.[].name' | grep -qE '^release/'; then
+            VERSION=$(curl -s -L -H "Accept: application/vnd.github+json" https://api.github.com/repos/ONLYOFFICE/document-server-package/branches | jq -r '.[] | select(.name|test("^release/")) | .name' | awk -F '/v' '{print $2}')  
+          else
+            VERSION=$(curl -s -L -H "Accept: application/vnd.github+json" https://api.github.com/repos/ONLYOFFICE/document-server-package/branches | jq -r '.[] | select(.name|test("^hotfix/")) | .name' | awk -F '/v' '{print $2}')
+          fi
           echo "ds-ver=${VERSION:-99.99.99}" >> "$GITHUB_OUTPUT"
 
   vagrant-up:


### PR DESCRIPTION
First, the value of the release branch is determined. If there is no branch, the value of the hotfix branch is accepted.