### PR TITLE
Updating the testing process, using Ubuntu runners

### DIFF
--- a/.github/workflows/ci-docs-test.yml
+++ b/.github/workflows/ci-docs-test.yml
@@ -67,8 +67,8 @@ jobs:
             os: debian12
             name: "Debian 12"
 
-          - distr: ubuntu
-            os: bionic64
+          - distr: generic
+            os: ubuntu1804
             name: "Ubuntu 18.04"            
 
           - distr: generic

--- a/.github/workflows/ci-docs-test.yml
+++ b/.github/workflows/ci-docs-test.yml
@@ -67,8 +67,8 @@ jobs:
             os: debian12
             name: "Debian 12"
 
-          - distr: generic
-            os: ubuntu1804
+          - distr: ubuntu
+            os: bionic64
             name: "Ubuntu 18.04"            
 
           - distr: generic
@@ -109,7 +109,7 @@ jobs:
                    OS='${{ matrix.os }}' \
                    DOWNLOAD_SCRIPT='-ds true' \
                    RAM='6000' \
-                   CPU='3' \
+                   CPU='2' \
                    ARGUMENTS="-arg '--skiphardwarecheck true --makeswap false'" \
                    vagrant up
         on_retry_command: |
@@ -132,8 +132,8 @@ jobs:
                     TEST_CASE='--local-install' \
                     DISTR='${{ matrix.distr }}' \
                     OS='${{ matrix.os }}' \
-                    RAM='9100' \
-                    CPU='3' \
+                    RAM='6000' \
+                    CPU='2' \
                     VER='-v ${{ env.VER }}' \
                     DOWNLOAD_SCRIPT='-ds false' \
                     TEST_REPO='-tr true' \

--- a/.github/workflows/ci-update.yml
+++ b/.github/workflows/ci-update.yml
@@ -13,11 +13,10 @@ on:
 
   workflow_dispatch:
 
-
 jobs:
   update-test:
     name: "Update test on ${{ matrix.name }}"
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     strategy:
       fail-fast: false
@@ -43,12 +42,12 @@ jobs:
             os: debian11
             name: "Debian 11"
 
-         #- distr: onlyoffice
-         #  os: bookworm64
-         #  name: "Debian 12"
+          - distr: onlyoffice
+            os: debian12
+            name: "Debian 12"
 
           - distr: onlyoffice
-            os: bionic64
+            os: ubuntu1804
             name: "Ubuntu 18.04"            
 
           - distr: onlyoffice
@@ -67,6 +66,11 @@ jobs:
       with:
         python-version: '3.x'
 
+    - name: Set up vagrant and virtualbox
+      run: |
+           sudo apt update -y 
+           sudo apt install vagrant virtualbox -y
+
     - name: Testing with update
       uses: nick-fields/retry@v2
       with:
@@ -79,8 +83,8 @@ jobs:
 
               TEST_CASE='--local-install' \
               DISTR='${{matrix.distr}}' \
-              RAM='9100' \
-              CPU='3' \
+              RAM='6000' \
+              CPU='2' \
               OS='docs-${{ matrix.os }}' \
               DOWNLOAD_SCRIPT='-ds false' \
               TEST_REPO='-tr true' \

--- a/.github/workflows/rebuild-boxes.yml
+++ b/.github/workflows/rebuild-boxes.yml
@@ -10,46 +10,46 @@ env:
 jobs:
   vagrant-up:
     name: "Rebuild box with ${{matrix.name}}"
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
           - distr: generic
             os: centos7
-            name: "CentOS 7"
+            name: centos7
 
           - distr: generic
             os: centos8s
-            name: "CentOS 8 Stream"
+            name: centos8s
 
           - distr: generic
             os: centos9s
-            name: "CentOS 9 Stream"
+            name: centos9s
 
           - distr: generic
             os: debian10
-            name: "Debian 10"
+            name: debian10
 
           - distr: generic
             os: debian11
-            name: "Debian 11"
+            name: debian11
 
-          - distr: debian
-            os: bookworm64
-            name: "Debian 12"
+          - distr: generic
+            os: debian12
+            name: debian12
 
           - distr: ubuntu
             os: bionic64
-            name: "Ubuntu 18.04"
+            name: ubuntu1804
 
           - distr: generic
             os: ubuntu2004
-            name: "Ubuntu 20.04"
+            name: ubuntu2004
 
           - distr: generic
             os: ubuntu2204
-            name: "Ubuntu 22.04"
+            name: ubuntu2204
 
     steps:
     - name: Checkout code
@@ -60,6 +60,11 @@ jobs:
       with:
         python-version: '3.x'
 
+    - name: Set up vagrant and virtualbox
+      run: |
+           sudo apt update -y 
+           sudo apt install vagrant virtualbox -y
+           
     - name: Login Vagrant cloud
       run: vagrant cloud auth login --token ${VAGRANT_TOKEN}
 
@@ -78,14 +83,14 @@ jobs:
                    DISTR='${{matrix.distr}}' \
                    OS='${{ matrix.os }}' \
                    DOWNLOAD_SCRIPT='-ds true' \
-                   RAM='9100' \
-                   CPU='3' \
+                   RAM='5000' \
+                   CPU='2' \
                    ARGUMENTS="-arg '--skiphardwarecheck true --makeswap false'" \
                    vagrant up
                 sleep 300
                 vagrant package --output repacked_${{ matrix.os }}.box
                 vagrant cloud publish \
-                   ${VAGRANT_ACCOUNT}/docs-${{ matrix.os }} \
+                   ${VAGRANT_ACCOUNT}/docs-${{ matrix.name }} \
                    $date virtualbox repacked_${{ matrix.os }}.box \
                    -d "Box with pre-installed docs" \
                    --version-description "Docs <version>" \


### PR DESCRIPTION
In all workflows: 

- Resources have been updated in accordance with Ubuntu runners. 
- The names of boxes for uploading to Vagrant Cloud were also standardized